### PR TITLE
Replace deprecated `extends App` with explicit `main` methods

### DIFF
--- a/firepower-core/src/main/scala/com/htmlism/firepower/core/CodeGenerator.scala
+++ b/firepower-core/src/main/scala/com/htmlism/firepower/core/CodeGenerator.scala
@@ -1,104 +1,105 @@
 package com.htmlism.firepower.core
 
-object CodeGenerator extends App:
-  val allLetters =
-    ('A' to 'Z')
-      .map(_.toString)
+object CodeGenerator:
+  def main(args: Array[String]): Unit =
+    val allLetters =
+      ('A' to 'Z')
+        .map(_.toString)
 
-  for n <- 1 to 3 do
-    val letters =
-      allLetters.take(n)
+    for n <- 1 to 3 do
+      val letters =
+        allLetters.take(n)
 
-    val nextLetter =
-      allLetters(n)
+      val nextLetter =
+        allLetters(n)
 
-    val typeParameterList =
-      letters.mkString(", ")
+      val typeParameterList =
+        letters.mkString(", ")
 
-    println(s"sealed trait Asm$n[$typeParameterList]:")
-    println("  def xs: List[String]")
-    println
-    println("  def oComment: Option[String]")
-    println
-    println(s"  def comment(s: String): Asm$n[$typeParameterList]")
-    println
-    println(s"  def andThen(that: Asm$n[$typeParameterList]): Asm$n[$typeParameterList] =")
-    println(s"    AndThen$n[$typeParameterList](this, that, None)")
-    println
-    println(s"  def widenWith[$nextLetter]: Asm${n + 1}[$typeParameterList, $nextLetter] =")
-    println(s"    Asm${n + 1}Instructions(xs, oComment)")
-    println
-    println(
-      s"case class AndThen$n[$typeParameterList](left: Asm$n[$typeParameterList], right: Asm$n[$typeParameterList], oComment: Option[String]) extends Asm$n[$typeParameterList]:"
-    )
-    println("  def xs: List[String] =")
-    println("    left.xs ++ right.xs")
-    println
-    println(s"  def comment(s: String): Asm$n[$typeParameterList] =")
-    println("    copy(oComment = Some(s))")
-    println
-    println(
-      s"case class Asm${n}Instructions[$typeParameterList](xs: List[String], oComment: Option[String] = None) extends Asm$n[$typeParameterList]:"
-    )
-    println(s"  def comment(s: String): Asm$n[$typeParameterList] =")
-    println("    copy(oComment = Some(s))")
-    println
+      println(s"sealed trait Asm$n[$typeParameterList]:")
+      println("  def xs: List[String]")
+      println
+      println("  def oComment: Option[String]")
+      println
+      println(s"  def comment(s: String): Asm$n[$typeParameterList]")
+      println
+      println(s"  def andThen(that: Asm$n[$typeParameterList]): Asm$n[$typeParameterList] =")
+      println(s"    AndThen$n[$typeParameterList](this, that, None)")
+      println
+      println(s"  def widenWith[$nextLetter]: Asm${n + 1}[$typeParameterList, $nextLetter] =")
+      println(s"    Asm${n + 1}Instructions(xs, oComment)")
+      println
+      println(
+        s"case class AndThen$n[$typeParameterList](left: Asm$n[$typeParameterList], right: Asm$n[$typeParameterList], oComment: Option[String]) extends Asm$n[$typeParameterList]:"
+      )
+      println("  def xs: List[String] =")
+      println("    left.xs ++ right.xs")
+      println
+      println(s"  def comment(s: String): Asm$n[$typeParameterList] =")
+      println("    copy(oComment = Some(s))")
+      println
+      println(
+        s"case class Asm${n}Instructions[$typeParameterList](xs: List[String], oComment: Option[String] = None) extends Asm$n[$typeParameterList]:"
+      )
+      println(s"  def comment(s: String): Asm$n[$typeParameterList] =")
+      println("    copy(oComment = Some(s))")
+      println
 
-  for n <- 1 to 3 do
-    val classNum =
-      n
+    for n <- 1 to 3 do
+      val classNum =
+        n
 
-    val letters =
-      allLetters.take(n)
+      val letters =
+        allLetters.take(n)
 
-    val typeParametersLong =
-      letters
-        .flatMap { s =>
-          List(s"$s : Reg", s"M$s <: MutationStatus")
-        }
-        .appended("Z : Monoid")
-        .mkString(", ")
+      val typeParametersLong =
+        letters
+          .flatMap { s =>
+            List(s"$s : Reg", s"M$s <: MutationStatus")
+          }
+          .appended("Z : Monoid")
+          .mkString(", ")
 
-    val typeParametersShort =
-      letters
-        .flatMap { s =>
-          List(s"$s", s"M$s")
-        }
-        .mkString(", ")
+      val typeParametersShort =
+        letters
+          .flatMap { s =>
+            List(s"$s", s"M$s")
+          }
+          .mkString(", ")
 
-    val parameters =
-      letters
-        .map { s =>
-          s"${s.toLowerCase}: StatefulRegister[$s, M$s]"
-        }
-        .appended("z: Z")
-        .mkString(", ")
+      val parameters =
+        letters
+          .map { s =>
+            s"${s.toLowerCase}: StatefulRegister[$s, M$s]"
+          }
+          .appended("z: Z")
+          .mkString(", ")
 
-    val nPlus =
-      n + 1
+      val nPlus =
+        n + 1
 
-    val arguments =
-      letters
-        .map(_.toLowerCase)
-        .mkString(", ")
+      val arguments =
+        letters
+          .map(_.toLowerCase)
+          .mkString(", ")
 
-    val newLetter =
-      allLetters(n)
+      val newLetter =
+        allLetters(n)
 
-    println(s"case class AsmProgram$classNum[$typeParametersLong]($parameters):")
-    println(
-      s"  def andThen(that: AsmProgram$classNum[$typeParametersShort, Z]): AsmProgram$classNum[$typeParametersShort, Z] ="
-    )
-    println(s"    AsmProgram$classNum($arguments, z |+| that.z)")
-    println()
-    println(s"  def widen[$newLetter : Reg]: AsmProgram$nPlus[$typeParametersShort, $newLetter, Ignores, Z] =")
-    println(s"    AsmProgram$nPlus($arguments, ??? : StatefulRegister[$newLetter, Ignores], z)")
-    println()
-    println(s"  def name(s: String): SubRoutine$classNum[$typeParametersShort, Z] =")
-    println(s"    SubRoutine$classNum(s, this)")
-    println()
+      println(s"case class AsmProgram$classNum[$typeParametersLong]($parameters):")
+      println(
+        s"  def andThen(that: AsmProgram$classNum[$typeParametersShort, Z]): AsmProgram$classNum[$typeParametersShort, Z] ="
+      )
+      println(s"    AsmProgram$classNum($arguments, z |+| that.z)")
+      println()
+      println(s"  def widen[$newLetter : Reg]: AsmProgram$nPlus[$typeParametersShort, $newLetter, Ignores, Z] =")
+      println(s"    AsmProgram$nPlus($arguments, ??? : StatefulRegister[$newLetter, Ignores], z)")
+      println()
+      println(s"  def name(s: String): SubRoutine$classNum[$typeParametersShort, Z] =")
+      println(s"    SubRoutine$classNum(s, this)")
+      println()
 
-    println(
-      s"case class SubRoutine$classNum[$typeParametersLong](name: String, program: AsmProgram$classNum[$typeParametersShort, Z])"
-    )
-    println()
+      println(
+        s"case class SubRoutine$classNum[$typeParametersLong](name: String, program: AsmProgram$classNum[$typeParametersShort, Z])"
+      )
+      println()

--- a/src/main/scala/com/htmlism/mos6502/dsl/DslDemo.scala
+++ b/src/main/scala/com/htmlism/mos6502/dsl/DslDemo.scala
@@ -7,38 +7,39 @@ import cats.syntax.all.*
 
 import com.htmlism.mos6502.model.*
 
-object DslDemo extends App:
-  val cpu =
-    new CPU
+object DslDemo:
+  def main(args: Array[String]): Unit =
+    val cpu =
+      new CPU
 
-  import registers.{A, X}
+    import registers.{A, X}
 
-  // address demonstration
-  withAssemblyContext { implicit ctx =>
-    val payloadLocation =
-      0x01.z
+    // address demonstration
+    withAssemblyContext { implicit ctx =>
+      val payloadLocation =
+        0x01.z
 
-    cpu.A = 0x40
+      cpu.A = 0x40
 
-    A.add(payloadLocation)
-  }
+      A.add(payloadLocation)
+    }
 
-  // a becomes others
-  withAssemblyContext { implicit ctx =>
-    cpu.A = cpu.X
-    cpu.A = cpu.Y
-  }
+    // a becomes others
+    withAssemblyContext { implicit ctx =>
+      cpu.A = cpu.X
+      cpu.A = cpu.Y
+    }
 
-  // demonstrate first example
-  withAssemblyContext { implicit ctx =>
-    cpu.A = 0xc0
+    // demonstrate first example
+    withAssemblyContext { implicit ctx =>
+      cpu.A = 0xc0
 
-    cpu.X = cpu.A
+      cpu.X = cpu.A
 
-    X.incr
+      X.incr
 
-    A.add(0xc4)
-  }
+      A.add(0xc4)
+    }
 
   def withAssemblyContext(f: AssemblyContext => Unit): Unit =
     val ctx: AssemblyContext =


### PR DESCRIPTION
### Motivation
- Remove deprecated usage of `extends App` from entrypoint objects to silence deprecation warnings and prepare for future Scala compatibility while keeping changes minimal.
- Preserve existing runtime behavior and local helper definitions with only the top-level execution blocks moved into explicit `main` methods.

### Description
- Replace `object DslDemo extends App` with `object DslDemo` and add `def main(args: Array[String]): Unit` moving the previous top-level execution code into `main` in `src/main/scala/com/htmlism/mos6502/dsl/DslDemo.scala`.
- Replace `object CodeGenerator extends App` with `object CodeGenerator` and add `def main(args: Array[String]): Unit` nesting the prior top-level generation logic under `main` in `firepower-core/src/main/scala/com/htmlism/firepower/core/CodeGenerator.scala`.
- All edits are minimal and largely whitespace/indentation and block nesting to avoid broader refactors.

### Testing
- Ran `rg -n "extends\\s+App" -S` to verify no remaining `extends App` occurrences and the search returned no matches.
- Performed `git status --short` and committed the change with a descriptive message, and `git show --stat` confirms the two modified files were recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a3a0db388330b9f37b3f15e71fe0)